### PR TITLE
Update to docs for MessageCatcher and EditText widgets

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
@@ -1,11 +1,13 @@
 caption: edit-text
 created: 20131024141900000
-modified: 20210519154352055
+modified: 20211022232005114
 tags: Widgets
 title: EditTextWidget
 type: text/vnd.tiddlywiki
 
 ! Introduction
+
+Look I added some text here.
 
 The edit text widget provides a user interface in the browser for editing text tiddler fields. The editing element is dynamically bound to the underlying tiddler value: changes to the tiddler are instantly reflected, and any edits are instantly propogated.
 
@@ -37,25 +39,3 @@ The content of the `<$edit-text>` widget is ignored.
 |refreshTitle |<<.from-version 5.1.23>> An optional tiddler title that makes the input field update whenever the specified tiddler changes |
 |disabled|<<.from-version "5.1.23">> Optional, disables the text input if set to "yes". Defaults to "no"|
 |fileDrop|<<.from-version "5.2.0">> Optional. When set to "yes" allows dropping or pasting images into the editor to import them. Defaults to "no"|
-
-! Notes
-
-One trap to be aware of is that the edit text widget //cannot be used// to edit a field of the tiddler that contains it. Each keypress results in the tiddler being re-rendered, which loses the cursor position within the text field.
-
-Instead, place the edit text widget in a [[template|TemplateTiddlers]] that references the tiddler you want to modify.
-
-For example, if you wanted the tiddler GettingStarted to edit the value of the "myconfig" field of the tiddler "AppSettings", you might do so by creating a separate tiddler "ChangeAppSettings" that contains the following:
-
-```
-<$edit-text tiddler="AppSettings" field="myconfig"/>
-```
-
-And reference the template in any other tiddler (e.g. GettingStarted) with `{{ChangeAppSettings}}`.
-
-This works when your use of the tiddler //is not// the AppSettings itself which would cause a recursion problem. In this latter case you have to save the fields to a temporary (or alternative) tiddler (sort of the reverse of above) like so:
-
-```
-<$edit-text tiddler="StoreAppSettings" field="myconfig"/>
-```
-
-In short the EditTextWidget //can not// change properties of the tiddler it is embedded in or part of. It can only change fields of //other// tiddlers. One could use ShadowTiddlers to accomplish the field storage if needed.

--- a/editions/tw5.com/tiddlers/widgets/MessageCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/MessageCatcherWidget.tid
@@ -1,12 +1,12 @@
 created: 20210309133636211
-modified: 20210711193113104
+modified: 20211022232020550
 tags: Widgets
 title: MessageCatcherWidget
 type: text/vnd.tiddlywiki
 
 ! Introduction
 
-<<.from-version "5.2.0">>
+<<.from-version "5.2.0">> Such a new and shiny widget.
 
 The message catcher widget traps [[messages|Messages]] dispatched within its child content, and allows invoking a series of ActionWidgets in response to those messages.
 
@@ -21,11 +21,13 @@ The content of the `<$messagecatcher>` widget is displayed normally.
 
 ! Variables
 
-The message catcher widget
+The message catcher widget sets the following variables within each action string:
 
 |!Variables |!Description |
 |`event-*` |All string-based properties of the `event` object, with the names prefixed with `event-` |
+|`list-event` |A list of the names of each the string-based properties of the `event` object (the names are not prefixed with `event-`) |
 |`event-paramObject-*` |All string-based properties of the `event.paramObject` object, with the names prefixed with `event-paramObject-` |
+|`list-event-paramObject` |A list of the names of each the string-based properties of the `event.paramObject` object (the names are not prefixed with `event-paramObject-`) |
 |`modifier` |For messages that originated with browser events, the modifier keys that were pressed when the event was fired. The possible modifiers are ''normal'' (no modifiers), ''ctrl'', ''ctrl-alt'', ''ctrl-shift'', ''alt'', ''alt-shift'', ''shift'' and ''ctrl-alt-shift'' |
 
 ! Example


### PR DESCRIPTION
I have just added some random text. Hmm. Markdown support and preview would be nice here, or we could just open a Github window to write the message there.