### PR TITLE
Update to docs for MessageCatcher and EditText widgets

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
@@ -1,11 +1,13 @@
 caption: edit-text
 created: 20131024141900000
-modified: 20211021091910134
+modified: 20211022232005114
 tags: Widgets
 title: EditTextWidget
 type: text/vnd.tiddlywiki
 
 ! Introduction
+
+Look I added some text here.
 
 The edit text widget provides a user interface in the browser for editing text tiddler fields. The editing element is dynamically bound to the underlying tiddler value: changes to the tiddler are instantly reflected, and any edits are instantly propogated.
 

--- a/editions/tw5.com/tiddlers/widgets/MessageCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/MessageCatcherWidget.tid
@@ -1,12 +1,12 @@
 created: 20210309133636211
-modified: 20210711193113104
+modified: 20211022232020550
 tags: Widgets
 title: MessageCatcherWidget
 type: text/vnd.tiddlywiki
 
 ! Introduction
 
-<<.from-version "5.2.0">>
+<<.from-version "5.2.0">> Such a new and shiny widget.
 
 The message catcher widget traps [[messages|Messages]] dispatched within its child content, and allows invoking a series of ActionWidgets in response to those messages.
 


### PR DESCRIPTION
I have just added some random text. Hmm. Markdown support and preview would be nice here, or we could just open a Github window to write the message there.