### PR TITLE
Docs: remove erroneous "selection constructor" tag from enlist-input operator. 

### DIFF
--- a/editions/tw5.com/tiddlers/filters/enlist-input Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/enlist-input Operator.tid
@@ -1,12 +1,12 @@
 caption: enlist-input
 created: 20201102215459192
-modified: 20201102221854719
+modified: 20211023071506784
 op-input: a [[selection of titles|Title Selection]]
 op-output: the titles stored as a [[title list|Title List]] in each input title
 op-purpose: select titles by interpreting each input title as a [[title list|Title List]]
 op-suffix: `dedupe` (the default) to remove duplicates, `raw` to leave duplicates untouched
 op-suffix-name: D
-tags: [[Filter Operators]] [[String Operators]] [[Selection Constructors]]
+tags: [[Filter Operators]] [[String Operators]]
 title: enlist-input Operator
 type: text/vnd.tiddlywiki
 


### PR DESCRIPTION
Docs: remove erroneous "selection constructor" tag from enlist-input operator.