### PR TITLE
Fixes typo in "SystemTag: $:/tags/ClassFilters/PageTemplate"

### DIFF
--- a/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_ClassFilters_PageTemplate.tid
+++ b/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_ClassFilters_PageTemplate.tid
@@ -6,4 +6,4 @@ tags: SystemTags
 title: SystemTag: $:/tags/ClassFilters/PageTemplate
 type: text/vnd.tiddlywiki
 
-The [[system tag|SystemTags]] `$:/tags/ClassFilters/PageTemplate` marks filters marks filters evaluated to dynamically add their output as CSS classes to the page template.
+The [[system tag|SystemTags]] `$:/tags/ClassFilters/PageTemplate` marks filters evaluated to dynamically add their output as CSS classes to the page template.


### PR DESCRIPTION
Removes erroneously repeated words.